### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=st7567sfGK 128x64 i2c LCD driver for Generation Klick
-version=0.4.3
+version=0.4.6
 author=Holger Lembke
 maintainer=Holger Lembke <lembke@gmail.com>
 sentence=st7567s i2c LC display library 128 x 64 pixel monochrome


### PR DESCRIPTION
Synchronize version.

Not updating the version field in the `library.properties` will result in PlatformIO's library crawler not being able to pick it up.

This should be followed up by a new Github release.

Actual fix for #4.